### PR TITLE
CI 워크플로우 생성

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,52 +1,55 @@
-  name: backend CI
+name: backend CI
 
-  on:
-    pull_request:
-      branches:
-        - 'develop'
-        - 'main'
-      types:
-        - opened
-        - synchronize
-        - reopened
-  jobs:
-    build:
-      runs-on: ubuntu-latest
+on:
+  pull_request:
+    branches:
+      - 'develop'
+      - 'main'
+    types:
+      - opened
+      - synchronize
+      - reopened
 
-      steps:
-        - name: Repository checkout
-          uses: actions/checkout@v4
+permissions: write-all
 
-        - name: Setup java 21
-          uses: actions/setup-java@v4
-          with:
-            distribution: 'temurin'
-            java-version: '21'
+jobs:
+  build:
+    runs-on: ubuntu-latest
 
-        - name: Cache gradle
-          uses: actions/cache@v3
-          with:
-            path: |
-              ~/.gradle/caches
-              ~/.gradle/wrapper
-            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-            restore-keys: |
-              ${{ runner.os }}-gradle-
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
 
-        - name: Grant permission to gradlew
-          run: chmod +x gradlew
+      - name: Setup java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
 
-        - name: Build and test with gradle
-          run: ./gradlew build --info
+      - name: Cache gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-        - name: Publish test results
-          uses: EnricoMi/publish-unit-test-result-action@v2
-          if: always()
-          with:
-            files: ${{ github.workspace }}/build/test-results/test/TEST-*.xml
+      - name: Grant permission to gradlew
+        run: chmod +x gradlew
 
-        - name: Publish test report
-          uses: mikepenz/action-junit-report@v4
-          if: always()
-          with:
-            report_paths: ${{ github.workspace }}/build/test-results/test/TEST-*.xml
+      - name: Build and test with gradle
+        run: ./gradlew build --info
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: ${{ github.workspace }}/build/test-results/test/TEST-*.xml
+
+      - name: Publish test report
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          report_paths: ${{ github.workspace }}/build/test-results/test/TEST-*.xml

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -4,6 +4,7 @@
     pull_request:
       branches:
         - 'develop'
+        - 'main'
       types:
         - opened
         - synchronize

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,52 @@
+  name: backend CI
+
+  on:
+    pull_request:
+      branches:
+        - 'develop'
+      types:
+        - opened
+        - synchronize
+        - reopened
+        - edited
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+
+      steps:
+        - name: Repository checkout
+          uses: actions/checkout@v4
+
+        - name: Setup java 21
+          uses: actions/setup-java@v4
+          with:
+            distribution: 'temurin'
+            java-version: '21'
+
+        - name: Cache gradle
+          uses: actions/cache@v3
+          with:
+            path: |
+              ~/.gradle/caches
+              ~/.gradle/wrapper
+            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+            restore-keys: |
+              ${{ runner.os }}-gradle-
+
+        - name: Grant permission to gradlew
+          run: chmod +x gradlew
+
+        - name: Build and test with gradle
+          run: ./gradlew build --info
+
+        - name: Publish test results
+          uses: EnricoMi/publish-unit-test-result-action@v2
+          if: always()
+          with:
+            files: ${{ github.workspace }}/build/test-results/test/TEST-*.xml
+
+        - name: Publish test report
+          uses: mikepenz/action-junit-report@v4
+          if: always()
+          with:
+            report_paths: ${{ github.workspace }}/build/test-results/test/TEST-*.xml

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -8,7 +8,6 @@
         - opened
         - synchronize
         - reopened
-        - edited
   jobs:
     build:
       runs-on: ubuntu-latest


### PR DESCRIPTION
## 🦡️ 관련 이슈
close #2 

## 📍주요 변경 사항
CI 워크플로우를 구성했습니다.
Github 공식문서와 각 팀에 CI 워크플로우를 많이 참고했습니다.
이후 PR에서 오류가 발생하는지 확인하고 고치도록 하겠습니다.

아래는 개인적인 정리 겸 각 부분에 대한 구현 이유입니다.
잘못된 정보나 수정하고 싶은 부분이 있다면 편하게 말씀해주세요~

### line 3~11
type을 설정하지 않으면 `opened`, `synchronize`, `reopened`에 적용된다고 합니다. `synchronize`는 HEAD가 바뀌거나 새로운 commit 이 추가되는 경우를 의미합니다. 이 외에 PR이 수정되는 경우도 차후 자동으로 PR을 생성하는 워크플로우가 들어가면 필요할 것 같아 넣어두었습니다.
> By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened.
[출처: Github 공식문서](https://docs.github.com/ko/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request)

### line 20~24
자바는 21 LTS 를 세팅하도록 설정했고, distribution은 'temurin'을 지정했습니다. 다양한 distribution 이 존재하는데, OpenJDK의 표준 구현이기 때문에 이를 사용하기로 결정했습니다.

추가적으로 코틀린 셋업을 위한 `fwilhe2/setup-kotlin` 워크플로우가 있지만, 이는 현 상황에서 불필요합니다.
해당 워크플로우는 kotlinc 등을 이용해서 코틀린 스크립트를 실행해야 하거나, 빌드 도구 없이 코틀린 파일을 실행시킬 때에 필요하기 때문입니다.
Gradle의 코틀린 패키지에 의해 관리되어 Java 셋업 및 Gradle 셋업으로 충분하다고 합니다.

### line 42~46
해당 워크플로우는 PR에서 테스트 결과를 확인할 수 있는 워크플로우입니다.
지정한 위치에 테스트 결과 레포트를 생성해줍니다.
위치 설정으로 인해 잘 동작하는지 확인이 필요한 부분입니다.

### line 48~52
해당 워크플로우는 PR 코멘트로 요약된 테스트 결과를 확인할 수 있는 워크플로우입니다.
어느 테스트가 성공했고 실패했는지를 확인할 수 있어 적용했습니다.
마찬가지로 위치 설정으로 인해 잘 동작하는지 확인이 필요한 부분입니다.

## 🎸기타
`EnricoMi/publish-unit-test-result-action`와 `mikepenz/action-junit-report` 외에도 테스트 커버리지를 확인할 수 있는 `jacocoTestReport`나 `codecov/codecov-action`등이 있지만 현 시점에서 불필요하다고 판단해 추가하지 않았습니다. 차후 필요하다면 추가하면 될 것 같습니다~
