### PR TITLE
CD 워크플로우 구축 및 도커 파일 설정

### DIFF
--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -1,0 +1,59 @@
+name: backend CD dev
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+
+      - name: Setup java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Cache gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant permission to gradlew
+        run: chmod +x gradlew
+
+      - name: Build and test with gradle
+        run: ./gradlew clean build
+
+      - name: Sign in Dockerhub
+        uses: docker/login-action@v1
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+
+      - name: Build the Docker image
+        run: docker build -f ./Dockerfile --platform linux/arm64 --no-cache -t ossori/ossori:dev .
+
+      - name: Push the Docker Image to Dockerhub
+        run: docker push ossori/ossori:dev
+
+  deploy:
+    needs: build
+    runs-on: [ self-hosted ]
+
+    steps:
+      - name: Pull docker image
+        run: sudo docker pull ossori/ossori:dev
+
+      - name: Docker compose up
+        run: sudo docker compose -f ~/docker/ossori-dev-compose.yml up -d

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM eclipse-temurin:21-jdk
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "-Duser.timezone=Asia/Seoul", "-Dfile.encoding=UTF-8", "/app.jar"]


### PR DESCRIPTION
## 🦡️ 관련 이슈
close #3 

## 📍주요 변경 사항
CD 워크플로우를 구현했고, 관련해서 도커 설정을 추가했습니다.

기본적인 구조는 `빌드 - 도커 이미지 생성 - 도커 허브로 업로드 - self-hosted runner 에서 인스턴스로 도커 이미지 풀 - 도커 컴포즈 실행` 입니다.

1. Builds job

이전 CI과 거의 유사하니 다른 부분을 설명하면, 테스트 레포팅을 위한 스텝을 삭제했고, 도커 이미지 빌드 및 도커 허브에 업로드 하는 스텝을 추가했습니다.

이를 위해 secret 에 docker hub 이름과 pat를 넣어주었습니다.

2. Deploy job

self-hosted runner가 해당 작업들을 ec2 인스턴스 아래에서 수행합니다.

앞서 ec2 인스턴스에서 self-hosted runner 관련 설정을 해줬고, 이는 깃허브 레포지토리 - Settings -  Actions - Runners 에서 확인할 수 있습니다.

수행하는 작업은 간단하게 이미지를 풀 받고, 이를 실행하는 것입니다.

docker compose 를 수행할 yml 파일은 github 에서 관리하지 않고 ec2 인스턴스에 바로 업로드했는데, 이는 github 에서 yml을 관리할 때에 이 파일을 인스턴스로 옮겨야 하는 작업이 추가로 필요해서 입니다.

self-hosted runner 로 가져가도록 하거나, ssh 로 접속해 파일을 직접 옮기거나 해야하는데, 이 과정의 장점은 yml 파일 또한 항상 최신의 것으로 유지할 수 있습니다. 하지만 규모가 작은 지금 시점에서 yml 파일의 변화가 매 CD 마다 관리되어야 할 필요성이 느껴지지 않아 직접 파일을 업로드하는 것으로 우선 구현했습니다.

CD도 CI와 마찬가지로, 머지되고 돌아가지 않는다면 빠르게 수정 PR 올릴께요~~

## 🎸기타

앞서 설명한 것 처럼, docker-compose.yml 파일을 어떻게 관리할지 논의해보고 싶습니다.

`직접 인스턴스에 옮긴다` vs `github에 올리고 파일을 옮기는 작업을 구현한다` 이 중 어느 방법이 나을까요?
