### PR TITLE
상세 레포지터리 조회 api 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,9 @@ group = "com.almumol"
 version = "0.0.1-SNAPSHOT"
 
 java {
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
+
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(21)
 	}

--- a/src/main/kotlin/com/almumol/ossori/global/exception/BadRequestException.kt
+++ b/src/main/kotlin/com/almumol/ossori/global/exception/BadRequestException.kt
@@ -1,0 +1,3 @@
+package com.almumol.ossori.global.exception
+
+data class BadRequestException(override val message: String) : RuntimeException()

--- a/src/main/kotlin/com/almumol/ossori/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/almumol/ossori/global/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,17 @@
+package com.almumol.ossori.global.exception
+
+import com.almumol.ossori.global.exception.dto.ExceptionResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException::class)
+    fun handleBadRequestException(exception: BadRequestException): ResponseEntity<ExceptionResponse> {
+        val response = ExceptionResponse(exception.message)
+        return ResponseEntity.badRequest()
+                .body(response)
+    }
+}

--- a/src/main/kotlin/com/almumol/ossori/global/exception/dto/ExceptionResponse.kt
+++ b/src/main/kotlin/com/almumol/ossori/global/exception/dto/ExceptionResponse.kt
@@ -1,0 +1,5 @@
+package com.almumol.ossori.global.exception.dto
+
+data class ExceptionResponse(
+        val message: String
+)

--- a/src/main/kotlin/com/almumol/ossori/project/controller/ProjectController.kt
+++ b/src/main/kotlin/com/almumol/ossori/project/controller/ProjectController.kt
@@ -1,0 +1,21 @@
+package com.almumol.ossori.project.controller
+
+import com.almumol.ossori.project.dto.response.ProjectResponse
+import com.almumol.ossori.project.service.ProjectService
+import lombok.RequiredArgsConstructor
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/projects")
+class ProjectController(
+        private val projectService: ProjectService
+) {
+
+    @GetMapping("/{id}")
+    fun findProject(@PathVariable id: Long): ProjectResponse =
+            projectService.findProjectById(id)
+}

--- a/src/main/kotlin/com/almumol/ossori/project/domain/Project.kt
+++ b/src/main/kotlin/com/almumol/ossori/project/domain/Project.kt
@@ -1,0 +1,56 @@
+package com.almumol.ossori.project.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
+
+@Entity
+data class Project(
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        val id: Long,
+
+        @Column(nullable = false, unique = true)
+        val name: String,
+
+        val description: String,
+
+        @Column(nullable = false)
+        val githubLink: String,
+
+        @Column(nullable = false)
+        val countingStar: Long,
+
+        @Column(nullable = false)
+        val issueCount: Long,
+
+        // CONTRIBUTING.md
+        val contributionGuide: String? = null,
+
+        // 이슈 생성 빈도
+        @Column(nullable = false)
+        val issueFrequency: Double,
+
+        // 머지 시간
+        @Column(nullable = false)
+        val timeToMerge: Double,
+
+        // PR 생성 빈도
+        @Column(nullable = false)
+        val pullRequestFrequency: Double,
+
+        // 고유한 기여자 수
+        @Column(nullable = false)
+        val uniqueContributors: Long,
+
+        // 스타 변화량
+        @Column(nullable = false)
+        val starDifference: Long,
+
+        // PR 최초 응답 시간
+        @Column(nullable = false)
+        val firstResponseTimeOfPullRequest: Double,
+)

--- a/src/main/kotlin/com/almumol/ossori/project/domain/Project.kt
+++ b/src/main/kotlin/com/almumol/ossori/project/domain/Project.kt
@@ -28,7 +28,7 @@ data class Project(
         val issueCount: Long,
 
         // CONTRIBUTING.md
-        val contributionGuide: String? = null,
+        val contributionGuideKey: String? = null,
 
         // 이슈 생성 빈도
         @Column(nullable = false)

--- a/src/main/kotlin/com/almumol/ossori/project/dto/response/ProjectResponse.kt
+++ b/src/main/kotlin/com/almumol/ossori/project/dto/response/ProjectResponse.kt
@@ -1,0 +1,40 @@
+package com.almumol.ossori.project.dto.response
+
+import com.almumol.ossori.project.domain.Project
+
+data class ProjectResponse(
+        val id: Long,
+        val name: String,
+        val description: String,
+        val githubLink: String,
+        val countingStar: Long,
+        val issueCount: Long,
+        val contributionGuideKey: String? = null,
+        val issueFrequency: Double,
+        val timeToMerge: Double,
+        val pullRequestFrequency: Double,
+        val uniqueContributors: Long,
+        val starDifference: Long,
+        val firstResponseTimeOfPullRequest: Double,
+) {
+
+    companion object {
+        fun from(project: Project): ProjectResponse = with(project) {
+            ProjectResponse(
+                    id,
+                    name,
+                    description,
+                    githubLink,
+                    countingStar,
+                    issueCount,
+                    contributionGuideKey,
+                    issueFrequency,
+                    timeToMerge,
+                    pullRequestFrequency,
+                    uniqueContributors,
+                    starDifference,
+                    firstResponseTimeOfPullRequest
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/almumol/ossori/project/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/almumol/ossori/project/repository/ProjectRepository.kt
@@ -1,0 +1,9 @@
+package com.almumol.ossori.project.repository
+
+import com.almumol.ossori.project.domain.Project
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ProjectRepository : JpaRepository<Project, Long> {
+}

--- a/src/main/kotlin/com/almumol/ossori/project/service/ProjectService.kt
+++ b/src/main/kotlin/com/almumol/ossori/project/service/ProjectService.kt
@@ -1,0 +1,21 @@
+package com.almumol.ossori.project.service
+
+import com.almumol.ossori.global.exception.BadRequestException
+import com.almumol.ossori.project.dto.response.ProjectResponse
+import com.almumol.ossori.project.repository.ProjectRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+
+@Service
+class ProjectService(
+        private val projectRepository: ProjectRepository
+) {
+
+    @Transactional
+    fun findProjectById(projectId: Long): ProjectResponse {
+        val project = projectRepository.findById(projectId)
+                .orElseThrow { BadRequestException("존재하지 않는 프로젝트입니다.") }
+
+        return ProjectResponse.from(project)
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=OSSori

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,25 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL;DATABASE_TO_LOWER=TRUE; # mysql 모드 설정ㅋ
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+    defer-datasource-initialization: true
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  sql:
+    init:
+      mode: always

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,5 @@
+INSERT INTO project (id, name, description, github_link, counting_star, issue_count, contribution_guide, issue_frequency, time_to_merge, pull_request_frequency, unique_contributors, star_difference, first_response_time_of_pull_request
+) VALUES (1, 'flutter', '뭐 대충 모바일 네이티브 만드는 거였나', 'https://github.com/flutter/flutter', 171000, 5000, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/flutter.md', 2.5, 5.2, 1.8, 30, 15, 2.3),
+         (2, 'kubernetes', '뭐 대충 도커 관련된 거', 'https://github.com/kubernetes/kubernetes', 115000, 1900, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/kubernetes.md', 1.2, 4.7, 0.9, 12, 5, 1.5),
+         (3, 'pinpoint', '뭐 대충 네이버에서 만든거', 'https://github.com/pinpoint-apm/pinpoint', 13600, 425, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/pinpoint.md', 3.0, 3.1, 2.2, 25, 20, 3.8),
+         (4, 'tensorflow', '뭐 대충 거', 'https://github.com/tensorflow/tensorflow', 190000, 887, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/tensorflow.md', 0.8, 2.9, 0.5, 8, 30, 2.0);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO project (id, name, description, github_link, counting_star, issue_count, contribution_guide, issue_frequency, time_to_merge, pull_request_frequency, unique_contributors, star_difference, first_response_time_of_pull_request
+INSERT INTO project (id, name, description, github_link, counting_star, issue_count, contribution_guide_key, issue_frequency, time_to_merge, pull_request_frequency, unique_contributors, star_difference, first_response_time_of_pull_request
 ) VALUES (1, 'flutter', '뭐 대충 모바일 네이티브 만드는 거였나', 'https://github.com/flutter/flutter', 171000, 5000, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/flutter.md', 2.5, 5.2, 1.8, 30, 15, 2.3),
          (2, 'kubernetes', '뭐 대충 도커 관련된 거', 'https://github.com/kubernetes/kubernetes', 115000, 1900, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/kubernetes.md', 1.2, 4.7, 0.9, 12, 5, 1.5),
          (3, 'pinpoint', '뭐 대충 네이버에서 만든거', 'https://github.com/pinpoint-apm/pinpoint', 13600, 425, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/pinpoint.md', 3.0, 3.1, 2.2, 25, 20, 3.8),


### PR DESCRIPTION
## 🦡️ 관련 이슈
close #8 

## 📍주요 변경 사항
- 프로젝트 단건 조회 api 구현 `api/v1/projects/{id}`
- 프로젝트 단건 응답 dto 구현
- Bad Request 예외 객체 구현
- 예외 핸들러 구현

## 🎸기타
- 단건 조회 메서드명을 `find`로 할지 `get`으로 할지 고민하다가 `find`로 했는데 어색한가요
- 예외 객체 및 핸들러 는 저희끼리 정한 바가 없어서 이전 프로젝트에서 했던 방향으로 했는데 변경 필요하면 말해주세용~
- 엔티티 -> DTO의 변경 로직은 DTO에 넣었습니다. 생성자 오버로딩 or 정적 팩토리 메서드 방식 중 고민하다가 `with()` 문으로 중복 project. 호출을 줄이고 싶어서 정적 팩토리 메서드로 결정했는데 이게 코틀린스러운 방법인진 모르겠네요. 이 부분만 같이 고민해주세요

추가) 그리고 관성적으로 `@Transactional`을 붙였는데 지금 생각해보니 단건 조회라 필요 없을 것 같네요. 이전 프로젝트에서는 컨벤션으로 모든 서비스 메서드에 붙이기로 했었는데, 트랜잭션 관련 쿼리가 추가적으로 항상 발생하므로 성능이 떨어진다는 글을 보기도 했어서 이 부분도 같이 고민해 보면 좋을 것 같아요. 회의 때 얘기해봐도 될 듯용