### PR TITLE
PR에 assignee, reviewer, milestone 을 자동으로 배정하는 워크플로우 구현

### DIFF
--- a/.github/workflows/assign-PR-information.yml
+++ b/.github/workflows/assign-PR-information.yml
@@ -1,0 +1,85 @@
+name: Assign PR Milestone, Assignee, Reviewers
+
+on:
+  pull_request:
+    branches:
+      - 'develop'
+    types:
+      - opened
+      - reopened
+
+permissions:
+  pull-requests: write
+  contents: write
+  issues: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      AUTHOR: ${{ github.event.pull_request.user.login }}
+      PR_DATE: ${{ github.event.pull_request.created_at }}
+
+    steps:
+      - name: Assign milestone
+        run: |
+          echo "PR 생성일: $PR_DATE"
+
+          MILESTONES=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/$REPO/milestones?state=open&per_page=100&sort=due_on&direction=desc")
+
+          MATCHING_ID=$(echo "$MILESTONES" | jq -r --arg PR_DATE "$PR_DATE" '
+            .[] 
+            | select(.due_on != null) 
+            | . as $milestone 
+            | ($milestone.due_on | fromdateiso8601) as $end
+            | ( $end - (60*60*24*20) ) as $start
+            | ( $PR_DATE | fromdateiso8601 ) as $date
+            | select($start <= $date and $end >= $date)
+            | $milestone.number' | head -n 1)
+
+          if [[ -z "$MATCHING_ID" ]]; then
+            echo "해당 날짜에 맞는 마일스톤이 없습니다."
+            exit 0
+          fi
+
+          echo "매칭된 마일스톤 ID: $MATCHING_ID"
+
+          curl -s -X PATCH \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/issues/$PR_NUMBER" \
+            -d "{\"milestone\": $MATCHING_ID}"
+
+      - name: Assign assignee
+        run: |
+          echo "작성자: $AUTHOR"
+
+          curl -s -X PATCH \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/issues/$PR_NUMBER" \
+            -d "{\"assignees\": [\"$AUTHOR\"]}"
+
+      - name: Assign reviewers
+        run: |
+          BACKEND=("hjk0761" "jminkkk" "slimsha2dy")
+          REVIEWERS=()
+          for USER in "${BACKEND[@]}"; do
+            if [[ "$USER" != "$AUTHOR" ]]; then
+              REVIEWERS+=("$USER")
+            fi
+          done
+          REVIEWERS_JSON=$(jq -n --argjson arr "$(printf '%s\n' "${REVIEWERS[@]}" | jq -R . | jq -s .)" '$arr')
+
+          echo "지정할 리뷰어: $REVIEWERS_JSON"
+
+          curl -s -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/pulls/$PR_NUMBER/requested_reviewers" \
+            -d "{\"reviewers\": $REVIEWERS_JSON}"
+


### PR DESCRIPTION
## 🦡️ 관련 이슈
close #17 

## 📍주요 변경 사항

생산성 관련 PR 입니다.

PR 작성 시 assignee, reviewer, milestone 을 배정하도록 하는 워크플로우입니다.

트리거는 PR 이 생성되거나 재오픈될때로 했습니다.

pr 본문이 바뀌거나 새로운 커밋이 push 되더라도 PR의 메타정보(reviewer, assignee, milestone 등)은 바뀌지 않는다고 생각해 synchronized 를 제외했습니다.

현재 백엔드 팀원밖에 없기에 전체 인원 중 PR을 작성한 본인을 제외한 나머지 인원을 모두 reviewer 에 할당하도록 구현했습니다.

마일스톤은 현재 날짜가 due_on 이전이고, due-on - 20일 이후일때 해당 마일스톤을 PR 에 배정하도록 했습니다.

마일스톤 생성은 수동으로 하고 있고, 그 기간을 3주(월 - 일 총 20일)로 두기로 했기에, 우선 이렇게 구현했습니다.

또한 due_on 기준 내림차순으로 정렬한 후 조건에 만족하는 첫 마일스톤을 배정해서 날짜가 겹치는 마일스톤이 있더라도 그 중 가장 최신의 것으로 배정하도록 했습니다.

마일스톤 정보엔 due_on(끝나는 날짜) 만 있고, 시작되는 날짜는 없더군요.

역시나 워크플로우인 만큼, 머지되고 잘못 돌아간다면 수정 PR 새로 올리겠습니다!

## 🎸기타

아래는 참고한 깃허브 REST api 공식문서입니다.

[PR에 reviewer 배정하기](https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28)
[이슈(PR을 포함함) 정보 업데이트하기](https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#update-an-issue)
[마일스톤 가져오기](https://docs.github.com/en/rest/issues/milestones?apiVersion=2022-11-28#list-milestones)

[github access token 의 헤더는 Bearer 여도, token이여도 된다.](https://docs.github.com/ko/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28)
