### PR TITLE
멀티모듈화에 따른 CD 수정

### DIFF
--- a/.github/scripts/build-docker-images.sh
+++ b/.github/scripts/build-docker-images.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+: "${GITHUB_OUTPUT:=/dev/null}"
+
+IMAGES=""
+
+append() {
+  if [ -z "$IMAGES" ]; then
+    IMAGES="$1"
+  else
+    IMAGES="$IMAGES,$1"
+  fi
+}
+
+for module in "$@"
+do
+  echo "Processing $module"
+  JAR_FILE=$(find artifacts/artifact-"$module" -name '*.jar' | head -n1)
+  cp "$JAR_FILE" "$module".jar
+  docker build -f ./Dockerfile --build-arg MODULE="$module" --platform linux/arm64 --no-cache -t ossori/ossori-$module:dev .
+  docker push ossori/ossori-"$module":dev
+  append ossori/ossori-"$module":dev
+done
+
+echo "images=$IMAGES" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/build-docker-images.sh
+++ b/.github/scripts/build-docker-images.sh
@@ -17,7 +17,7 @@ do
   echo "Processing $module"
   JAR_FILE=$(find artifacts/artifact-"$module" -name '*.jar' | head -n1)
   cp "$JAR_FILE" "$module".jar
-  docker build -f ./Dockerfile --build-arg MODULE="$module" --platform linux/arm64 --no-cache -t ossori/ossori-"$module":dev .
+  docker build -f ./Dockerfile --build-arg MODULE="$module" --platform linux/arm64 -t ossori/ossori-"$module":dev .
   docker push ossori/ossori-"$module":dev
   append ossori/ossori-"$module":dev
 done

--- a/.github/scripts/build-docker-images.sh
+++ b/.github/scripts/build-docker-images.sh
@@ -17,7 +17,7 @@ do
   echo "Processing $module"
   JAR_FILE=$(find artifacts/artifact-"$module" -name '*.jar' | head -n1)
   cp "$JAR_FILE" "$module".jar
-  docker build -f ./Dockerfile --build-arg MODULE="$module" --platform linux/arm64 --no-cache -t ossori/ossori-$module:dev .
+  docker build -f ./Dockerfile --build-arg MODULE="$module" --platform linux/arm64 --no-cache -t ossori/ossori-"$module":dev .
   docker push ossori/ossori-"$module":dev
   append ossori/ossori-"$module":dev
 done

--- a/.github/scripts/extract-changed-modules.sh
+++ b/.github/scripts/extract-changed-modules.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+: "${GITHUB_OUTPUT:=/dev/null}"
+
+git fetch origin "$1":"$1"
+CHANGED=$(git diff --name-only origin/"$1"...HEAD)
+
+MODULES=""
+
+append() {
+  if [ -z "$MODULES" ]; then
+    MODULES="$1"
+  else
+    MODULES="$MODULES,$1"
+  fi
+}
+
+echo "$CHANGED" | grep -q '^module-api/' && append "module-api"
+echo "$CHANGED" | grep -q '^module-batch/' && append "module-batch"
+echo "$CHANGED" | grep -q '^module-core/module-domain/' && append "module-core:module-domain"
+echo "$CHANGED" | grep -q '^module-core/module-client/' && append "module-core:module-client"
+echo "$CHANGED" | grep -q '^module-core/module-infra/' && append "module-core:module-infra"
+
+echo "변경된 모듈 목록: $MODULES"
+echo "modules=$MODULES" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/find-dependant-modules.sh
+++ b/.github/scripts/find-dependant-modules.sh
@@ -15,5 +15,5 @@ executables_json=$(echo "$executables" | tr ',' '\n' | jq -R . | jq -s . | jq -c
 echo "candidates_json=${candidates_json}"
 echo "executables_json=${executables_json}"
 
-echo "candidates=\"${candidates_json}\"" >> "$GITHUB_OUTPUT"
-echo "executables=\"${executables_json}\"" >> "$GITHUB_OUTPUT"
+echo "candidates=${candidates_json}" >> "$GITHUB_OUTPUT"
+echo "executables=${executables_json}" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/find-dependant-modules.sh
+++ b/.github/scripts/find-dependant-modules.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+: "${GITHUB_OUTPUT:=/dev/null}"
+
+if ! command -v jq &> /dev/null; then
+  sudo apt-get update && sudo apt-get install -y jq
+fi
+
+output=$(./gradlew findDependentModules -PchangedModules="$1")
+candidates=$(echo "$output" | grep "candidates=" | cut -d'=' -f2)
+executables=$(echo "$output" | grep "executables=" | cut -d'=' -f2)
+candidates_json=$(echo "$candidates" | tr ',' '\n' | jq -R . | jq -s .)
+executables_json=$(echo "$executables" | tr ',' '\n' | jq -R . | jq -s .)
+
+echo "candidates=$candidates_json" >> "$GITHUB_OUTPUT"
+echo "executables=$executables_json" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/find-dependant-modules.sh
+++ b/.github/scripts/find-dependant-modules.sh
@@ -7,10 +7,19 @@ if ! command -v jq &> /dev/null; then
 fi
 
 output=$(./gradlew findDependentModules -PchangedModules="$1")
+echo "output=${output}"
 candidates=$(echo "$output" | grep "candidates=" | cut -d'=' -f2)
 executables=$(echo "$output" | grep "executables=" | cut -d'=' -f2)
+echo "candidates=$candidates"
+echjo "executables=$executables"
 candidates_json=$(echo "$candidates" | tr ',' '\n' | jq -R . | jq -s .)
 executables_json=$(echo "$executables" | tr ',' '\n' | jq -R . | jq -s .)
+echo "candidates_json=${candidates_json}"
+echo "executables_json=${executables_json}"
+candidates_json=$(echo "$candidates" | tr ',' '\n' | jq -R 'gsub("^\\s+|\\s+$"; "")' | jq -s .)
+executables_json=$(echo "$executables" | tr ',' '\n' | jq -R 'gsub("^\\s+|\\s+$"; "")' | jq -s .)
+echo "candidates_json=${candidates_json}"
+echo "executables_json=${executables_json}"
 
 echo "candidates=\"${candidates_json}\"" >> "$GITHUB_OUTPUT"
 echo "executables=\"${executables_json}\"" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/find-dependant-modules.sh
+++ b/.github/scripts/find-dependant-modules.sh
@@ -10,14 +10,8 @@ output=$(./gradlew findDependentModules -PchangedModules="$1")
 echo "output=${output}"
 candidates=$(echo "$output" | grep "candidates=" | cut -d'=' -f2)
 executables=$(echo "$output" | grep "executables=" | cut -d'=' -f2)
-echo "candidates=$candidates"
-echjo "executables=$executables"
-candidates_json=$(echo "$candidates" | tr ',' '\n' | jq -R . | jq -s .)
-executables_json=$(echo "$executables" | tr ',' '\n' | jq -R . | jq -s .)
-echo "candidates_json=${candidates_json}"
-echo "executables_json=${executables_json}"
-candidates_json=$(echo "$candidates" | tr ',' '\n' | jq -R 'gsub("^\\s+|\\s+$"; "")' | jq -s .)
-executables_json=$(echo "$executables" | tr ',' '\n' | jq -R 'gsub("^\\s+|\\s+$"; "")' | jq -s .)
+candidates_json=$(echo "$candidates" | tr ',' '\n' | jq -R . | jq -s . | jq -c .)
+executables_json=$(echo "$executables" | tr ',' '\n' | jq -R . | jq -s . | jq -c .)
 echo "candidates_json=${candidates_json}"
 echo "executables_json=${executables_json}"
 

--- a/.github/scripts/find-dependant-modules.sh
+++ b/.github/scripts/find-dependant-modules.sh
@@ -12,5 +12,5 @@ executables=$(echo "$output" | grep "executables=" | cut -d'=' -f2)
 candidates_json=$(echo "$candidates" | tr ',' '\n' | jq -R . | jq -s .)
 executables_json=$(echo "$executables" | tr ',' '\n' | jq -R . | jq -s .)
 
-echo "candidates=$candidates_json" >> "$GITHUB_OUTPUT"
-echo "executables=$executables_json" >> "$GITHUB_OUTPUT"
+echo "candidates=\"${candidates_json}\"" >> "$GITHUB_OUTPUT"
+echo "executables=\"${executables_json}\"" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -58,5 +58,5 @@ jobs:
             module_name="${name_with_prefix#ossori-}"
             container_name="ossori-dev-${module_name}"
             sudo docker rm -f "$container_name" || true
-            sudo docker compose -f ~/docker/"$module_name"/docker-compose.yml up -d
+            sudo docker compose -f ~/docker/"$module_name"/docker-compose-dev.yml up -d
           done

--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -8,32 +8,27 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.image.outputs.images }}
 
     steps:
       - name: Repository checkout
         uses: actions/checkout@v4
 
-      - name: Setup java 21
-        uses: actions/setup-java@v4
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          path: artifacts
+          merge-multiple: true
 
-      - name: Cache gradle
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      - name: Grant permission to gradlew
-        run: chmod +x gradlew
-
-      - name: Build and test with gradle
-        run: ./gradlew clean build
+      - name: Check downloaded artifacts
+        id: check_artifacts
+        run: |
+          echo "다운로드된 artifact 목록:"
+          ls artifacts
+          MODULES=$(ls artifacts | grep '^artifact-')
+          MODULES=$(echo "$MODULES" | sed 's/^artifact-//')
+          echo "modules=$MODULES" >> $GITHUB_OUTPUT
 
       - name: Sign in Dockerhub
         uses: docker/login-action@v1
@@ -41,19 +36,22 @@ jobs:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
 
-      - name: Build the Docker image
-        run: docker build -f ./Dockerfile --platform linux/arm64 --no-cache -t ossori/ossori:dev .
+      - name: Make scripts executable
+        run: chmod +x .github/scripts/*.sh
 
-      - name: Push the Docker Image to Dockerhub
-        run: docker push ossori/ossori:dev
+      - name: Build and push the Docker Image
+        id: image
+        run: .github/scripts/build-docker-images.sh ${{ steps.check_artifacts.outputs.modules }}
 
   deploy:
     needs: build
     runs-on: [ self-hosted ]
 
     steps:
-      - name: Pull docker image
-        run: sudo docker pull ossori/ossori:dev
-
-      - name: Docker compose up
-        run: sudo docker compose -f ~/docker/ossori-dev-compose.yml up -d
+      - name: Pull docker image and compose up
+        run: |
+          for image in $(echo "${{ needs.build.outputs.images }}" | tr ',' ' ')
+          do
+            sudo docker pull $image
+            sudo docker compose -f ~/docker/ossori-dev-compose.yml up -d
+          done

--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -53,5 +53,8 @@ jobs:
           for image in $(echo "${{ needs.build.outputs.images }}" | tr ',' ' ')
           do
             sudo docker pull $image
-            sudo docker compose -f ~/docker/ossori-dev-compose.yml up -d
+            name_with_registry="${image%%:*}"
+            name_with_prefix="${name_with_registry##*/}"
+            module_name="${name_with_prefix#ossori-}"
+            sudo docker compose -f ~/docker/"$module_name"/docker-compose.yml up -d
           done

--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -56,5 +56,7 @@ jobs:
             name_with_registry="${image%%:*}"
             name_with_prefix="${name_with_registry##*/}"
             module_name="${name_with_prefix#ossori-}"
+            container_name="ossori-dev-${module_name}"
+            sudo docker rm -f "$container_name" || true
             sudo docker compose -f ~/docker/"$module_name"/docker-compose.yml up -d
           done

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build and test with gradle
         if: ${{ matrix.module != '' }}
-        run: ./gradlew :${{ matrix.module }}:build --info
+        run: ./gradlew ${{ matrix.module }}:build --info
 
       - name: Save build files if executable modules
         if: contains(fromJSON(needs.detach.outputs.executables), matrix.module)

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -31,12 +31,12 @@ jobs:
       - name: Make scripts executable
         run: chmod +x .github/scripts/*.sh
 
-      - id: extract
-        name: extract changed module names
+      - name: extract changed module names
+        id: extract
         run: .github/scripts/extract-changed-modules.sh ${{ github.base_ref }}
 
-      - id: target
-        name: find targets
+      - name: find targets
+        id: target
         run: .github/scripts/find-dependant-modules.sh ${{ steps.extract.outputs.modules }}
 
   build:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       modules: ${{ steps.extract.outputs.modules }}
+      candidates: ${{ steps.target.outputs.candidates }}
+      executables: ${{ steps.target.outputs.executables }}
 
     steps:
       - name: Repository checkout
@@ -26,36 +28,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Make scripts executable
+        run: chmod +x .github/scripts/*.sh
+
       - id: extract
         name: extract changed module names
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-          
-          MODULES=()
-          
-          echo "$CHANGED" | grep -q '^module-api/' && MODULES+=("module-api")
-          echo "$CHANGED" | grep -q '^module-batch/' && MODULES+=("module-batch")
-          echo "$CHANGED" | grep -q '^module-core/module-domain/' && MODULES+=("module-core:module-domain")
-          echo "$CHANGED" | grep -q '^module-core/module-client/' && MODULES+=("module-core:module-client")
-          echo "$CHANGED" | grep -q '^module-core/module-infra/' && MODULES+=("module-core:module-infra")
+        run: .github/scripts/extract-changed-modules.sh ${{ github.base_ref }}
 
-          echo "변경된 모듈 목록: ${MODULES[@]}"
-          
-          if
-            [ ${#MODULES[@]} -eq 0 ]; then
-            echo "No changed modules"
-            exit 0
-          fi
-          
-          echo "modules=$(jq -c -n --argjson mods "$(printf '%s\n' "${MODULES[@]}" | jq -R . | jq -s .)" '$mods')" >> $GITHUB_OUTPUT
+      - id: target
+        name: find targets
+        run: .github/scripts/find-dependant-modules.sh ${{ steps.extract.outputs.modules }}
 
   build:
     needs: detach
-    if: ${{ needs.detach.outputs.modules && needs.detach.outputs.modules != '[]' }}
+    if: ${{ needs.detach.outputs.candidates && needs.detach.outputs.candidates != '[]' }}
     strategy:
       matrix:
-        module: ${{ fromJSON(needs.detach.outputs.modules) }}
+        module: ${{ fromJSON(needs.detach.outputs.candidates) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -86,6 +75,13 @@ jobs:
       - name: Build and test with gradle
         if: ${{ matrix.module != '' }}
         run: ./gradlew :${{ matrix.module }}:build --info
+
+      - name: Save build files if executable modules
+        if: contains(fromJSON(needs.detach.outputs.executables), matrix.module)
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-${{ matrix.module }}
+          path: ${{ matrix.module }}/build/libs/*.jar
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Build and test with gradle
         if: ${{ matrix.module != '' }}
-        run: ./gradlew ${{ matrix.module }}:build --info
+        run: ./gradlew :${{ matrix.module }}:build --info
 
       - name: Save build files if executable modules
         if: contains(fromJSON(needs.detach.outputs.executables), matrix.module)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:21-jdk
-ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} app.jar
+ARG MODULE
+COPY ${MODULE}.jar app.jar
 ENTRYPOINT ["java", "-jar", "-Duser.timezone=Asia/Seoul", "-Dfile.encoding=UTF-8", "/app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,3 +32,61 @@ subprojects {
         "testRuntimeOnly"("org.junit.platform:junit-platform-launcher")
     }
 }
+
+tasks.register("findDependentModules") {
+    group = "dependency"
+    description = "변경된 모듈에 의존하는 실행 모듈들을 출력합니다."
+
+    val changedModules = project.findProperty("changedModules")
+        ?.toString()
+        ?.takeIf { it.isNotBlank() }
+        ?.split(",")
+        ?.map(String::trim)
+        ?.map { if (it.startsWith(":")) it else ":$it" }
+        ?: emptyList()
+
+    doLast {
+        val moduleGraph = mutableMapOf<String, MutableSet<String>>()
+
+        rootProject.subprojects.forEach { proj ->
+            proj.configurations
+                .flatMap { it.dependencies }
+                .filterIsInstance<ProjectDependency>()
+                .forEach { dep ->
+                    val dependents = moduleGraph.getOrPut(dep.path) { mutableSetOf() }
+                    dependents.add(proj.path)
+                }
+        }
+
+        println(moduleGraph)
+
+        val visited = mutableSetOf<String>()
+        val candidates = mutableSetOf<String>()
+
+        fun traverse(module: String) {
+            if (module in visited) return
+            visited.add(module)
+            moduleGraph[module]?.forEach {
+                traverse(it)
+            }
+            candidates.add(module)
+        }
+
+        changedModules.forEach {
+            traverse(it)
+        }
+
+        val executableModules = candidates.filter { module ->
+            val project = rootProject.project(module)
+            project.fileTree("src/main").any {
+                it.name.endsWith("Application.kt")
+            }
+        }
+
+        val candidatesString = candidates.joinToString(",")
+        val executablesString = executableModules.joinToString(",")
+
+        println("candidates=$candidatesString")
+        println("executables=$executablesString")
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ tasks.register("findDependentModules") {
             moduleGraph[module]?.forEach {
                 traverse(it)
             }
-            candidates.add(module)
+            candidates.add(module.removePrefix(":"))
         }
 
         changedModules.forEach {

--- a/module-api/build.gradle.kts
+++ b/module-api/build.gradle.kts
@@ -18,6 +18,15 @@ dependencies {
     implementation ("com.h2database:h2")
 }
 
+sourceSets {
+    main {
+        resources {
+            srcDir(project(":module-core:module-client").file("src/main/resources"))
+        }
+    }
+}
+
+
 tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootJar> {
     mainClass.set("OssoriApplication")
 }

--- a/module-api/src/main/resources/application-dev.yml
+++ b/module-api/src/main/resources/application-dev.yml
@@ -1,0 +1,39 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+    import:
+      - classpath:application-client.yml
+
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL;DATABASE_TO_LOWER=TRUE; # mysql 모드 설정ㅋ
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+    defer-datasource-initialization: true
+
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  sql:
+    init:
+      mode: always
+
+config:
+  cors:
+    mapping: /**
+    origins:
+      - http://localhost:3000
+    methods:
+      - "*"

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -29,3 +29,11 @@ security:
     repository_base_url: https://api.github.com/repos
     search_repository_base_url: https://api.github.com/search/repositories
     token: test_pat
+
+config:
+  cors:
+    mapping: /**
+    origins:
+      - http://localhost:3000
+    methods:
+      - "*"

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -1,37 +1,3 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:test;MODE=MySQL;DATABASE_TO_LOWER=TRUE; # mysql 모드 설정ㅋ
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: true
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
-        format_sql: true
-    defer-datasource-initialization: true
-
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-
-  sql:
-    init:
-      mode: always
-
-  config:
-    import:
-      - classpath:application-client.yml
-
-config:
-  cors:
-    mapping: /**
-    origins:
-      - http://localhost:3000
-    methods:
-      - "*"
+  profiles:
+    active: dev

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -23,3 +23,9 @@ spring:
   sql:
     init:
       mode: always
+
+security:
+  github:
+    repository_base_url: https://api.github.com/repos
+    search_repository_base_url: https://api.github.com/search/repositories
+    token: test_pat

--- a/module-api/src/main/resources/application.yml
+++ b/module-api/src/main/resources/application.yml
@@ -24,11 +24,9 @@ spring:
     init:
       mode: always
 
-security:
-  github:
-    repository_base_url: https://api.github.com/repos
-    search_repository_base_url: https://api.github.com/search/repositories
-    token: test_pat
+  config:
+    import:
+      - classpath:application-client.yml
 
 config:
   cors:

--- a/module-core/module-client/src/main/resources/application-client.yml
+++ b/module-core/module-client/src/main/resources/application-client.yml
@@ -3,7 +3,3 @@ security:
     repository_base_url: https://api.github.com/repos
     search_repository_base_url: https://api.github.com/search/repositories
     token: test_pat
-
-spring:
-  jpa:
-    defer-datasource-initialization: true

--- a/module-core/module-domain/src/main/kotlin/global/config/CorsConfig.kt
+++ b/module-core/module-domain/src/main/kotlin/global/config/CorsConfig.kt
@@ -1,4 +1,4 @@
-package com.almumol.ossori.global.config
+package almumol.ossori.global.config
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean

--- a/module-core/module-domain/src/main/kotlin/global/config/CorsProperties.kt
+++ b/module-core/module-domain/src/main/kotlin/global/config/CorsProperties.kt
@@ -1,4 +1,4 @@
-package com.almumol.ossori.global.config
+package almumol.ossori.global.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 

--- a/module-core/module-domain/src/main/resources/data.sql
+++ b/module-core/module-domain/src/main/resources/data.sql
@@ -1,5 +1,0 @@
-INSERT INTO project (id, name, description, github_link, counting_star, issue_count, contribution_guide_key, issue_frequency, time_to_merge, pull_request_frequency, unique_contributors, star_difference, first_response_time_of_pull_request
-) VALUES (1, 'flutter', '뭐 대충 모바일 네이티브 만드는 거였나', 'https://github.com/flutter/flutter', 171000, 5000, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/flutter.md', 2.5, 5.2, 1.8, 30, 15, 2.3),
-         (2, 'kubernetes', '뭐 대충 도커 관련된 거', 'https://github.com/kubernetes/kubernetes', 115000, 1900, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/kubernetes.md', 1.2, 4.7, 0.9, 12, 5, 1.5),
-         (3, 'pinpoint', '뭐 대충 네이버에서 만든거', 'https://github.com/pinpoint-apm/pinpoint', 13600, 425, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/pinpoint.md', 3.0, 3.1, 2.2, 25, 20, 3.8),
-         (4, 'tensorflow', '뭐 대충 거', 'https://github.com/tensorflow/tensorflow', 190000, 887, 'https://ossori.s3.ap-northeast-2.amazonaws.com/contributing/tensorflow.md', 0.8, 2.9, 0.5, 8, 30, 2.0);


### PR DESCRIPTION
## 🦡️ 관련 이슈
close #29 

## 📍주요 변경 사항

멀티 모듈화에 따른 CD 수정입니다.

이전 CD와의 가장 큰 차이점은 실행 모듈(현재 api)만이 배포되어야 하므로 해당 jar 파일을 기존 방법(docker)대로 배포합니다.

이에 따라서 CI 또한 '기존 변경된 모듈만 확인' 에서 '변경된 모듈과 그에 의존하는 모듈들 확인 및 그 중 실행 가능한 모듈을 빌드해 아티팩트에 올림' 으로 수정되었습니다.

CD 도 아티팩트에 올라온 파일들을 가져와, 적절한 docker-compose.yml 을 찾아 배포하도록 했습니다.

docker-compose 도 우리 인스턴스 들어가보면 docker/{모듈명} 아래에 만들어두었어요.

저번 회의때 이야기한 방향대로 구현해보았습니다.

허나 하나 아쉬운점은 너무 자동화를 의식해서 구현하려고 하니 쓸데없이 길어진듯한 느낌입니다.

지금은 실행모듈이 api 하나라서 사실 CD 워크플로우가 저렇게 길 필요도 없는데 batch 모듈도 실행 모듈이 될 걸 의식해서 짜게 된 것 같아요.

그래도 자동화하는 부분들은 최대한 스크립트로 빼서 관리하려고 했고 너무 오버 엔지니어링인 것 같다고 생각이 들면 단순하게 모듈명을 지정하는 과정으로 바꿀 수도 있어요. 그러니 편하게 코드 리뷰 주시면 감사하겠습니다!!

## 🎸기타

코드 보면서 저도 잘 돌아갈지 확신이 없네요,,, 궁금한 점은 편하게 코멘트 달아주시면 이야기해봐요!

CI 와 마찬가지로, 들어가고 돌아가지 않는다면 수정 PR 빠르게 올려보겠습니다..ㅎㅎ
