### PR TITLE
CI 워크플로우에서 생성된 아티팩트를 CD 워크플로우가 사용하도록 수정

### DIFF
--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -17,6 +17,13 @@ jobs:
       - name: Repository checkout
         uses: actions/checkout@v4
 
+      - name: Check if artifacts exist
+        run: |
+          if [ ! -d "./artifacts" ] || [ -z "$(ls -A ./artifacts)" ]; then
+            echo "No artifacts found."
+            exit 0
+          fi
+
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -1,9 +1,11 @@
 name: backend CD dev
 
 on:
-  push:
+  workflow_run:
+    workflows: [backend CI]
+    types: [completed]
     branches:
-      - develop
+      - 'develop'
 
 jobs:
   build:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -12,6 +12,12 @@ on:
     paths-ignore:
       - 'module-frontend/**'
 
+  push:
+    branches:
+      - develop
+    paths-ignore:
+      - 'module-frontend/**'
+
 permissions: write-all
 
 jobs:


### PR DESCRIPTION
## 🦡️ 관련 이슈
close #32 

## 📍주요 변경 사항

기존 CI / CD 과정은 서로 다른 워크플로우로 동작하기 때문에 CI 워크플로우에서 생성된 파일을 아티팩트에 올려도 CD 워크플로우에선 이를 가져와 사용할 수 없었습니다.

이를 위한 해결책은 1. S3와 같은 기타 저장소를 통해 아티팩트 공유 2. CI 워크플로우에서 도커 이미지를 만들어 도커 허브에 업로드 3. 워크플로우 간 아티팩트를 공유하도록 수정 이 있었고, 도커 이미지 빌드는 CI의 책임이 아니기 때문에 2번은 제외, 추가 저장소로 소통하는 과정보다 워크플로우 내부에서 해결하는 게 안정성이 높고 비용이 적다고 판단해 1번을 제외하고 3번 선택지로 구현했습니다.

자세하게 설명하면 on.workflow_run 옵션을 통해 워크플로우의 선행관계를 지정할 수 있고, 이 경우 두 워크플로우 간 아티팩트를 공유할 수 있습니다.

따라서 이를 위해 CI / CD 워크플로우의 트리거를 바꾸게 되었습니다.

기존 CI는 develop, main 브랜치로 pr이 생성될 때 동작했고, dev CD 는 develop 브랜치로 push 가 일어날 때(RP이 merge되면) 동작했습니다.

실행 관점이 다른 두 워크플로우를 연결하기 위해 CI 워크플로우의 트리거를 develop 브랜치로 push 되는 경우에도 동작하도록 추가했고, CD 워크플로우는 on.workflow_run 을 통해 CI 워크플로우가 완료되면 동작하도록 하되, develop 브랜치가 아닌경우 배포 과정을 수행하지 않고 종료하도록 했습니다.

## 🎸기타

마찬가지로 CD에 오류가 생긴다면 추가 PR 올려서 해결하도록 하겠슴니다..ㅎㅎ

CI 워크플로우의 트리거에 on.push.branches 에 develop 만 둔 이유는 이후에 운영 CI, CD가 들어올 때 main을 추가하려고 해서 입니다.
