### PR TITLE
PR merge 에서 CI 수행 시 이전 커밋을 기준으로 변경점을 확인하도록 수정

### DIFF
--- a/.github/scripts/extract-changed-modules.sh
+++ b/.github/scripts/extract-changed-modules.sh
@@ -2,8 +2,21 @@
 
 : "${GITHUB_OUTPUT:=/dev/null}"
 
-git fetch origin "$1":"$1"
-CHANGED=$(git diff --name-only origin/"$1"...HEAD)
+if [ -z "$1" ]; then
+  echo "Argument for base branch needed"
+  exit 0
+fi
+
+BASE=$1
+
+if git show-ref --verify --quiet refs/remotes/origin/"$BASE"; then
+  git fetch origin "$BASE":"$BASE"
+  DIFF_TARGET="origin/$BASE"
+else
+  DIFF_TARGET="$BASE"
+fi
+
+CHANGED=$(git diff --name-only "$DIFF_TARGET"...HEAD)
 
 MODULES=""
 

--- a/.github/workflows/backend-cd-dev.yml
+++ b/.github/workflows/backend-cd-dev.yml
@@ -18,19 +18,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check if artifacts exist
+        id: check_artifacts
         run: |
           if [ ! -d "./artifacts" ] || [ -z "$(ls -A ./artifacts)" ]; then
             echo "No artifacts found."
+            echo "has_artifacts=false" >> $GITHUB_OUTPUT
             exit 0
           fi
+          echo "has_artifacts=true" >> $GITHUB_OUTPUT
 
       - name: Download artifacts
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Check downloaded artifacts
+        if: steps.check_artifacts.outputs.has_artifacts == 'true'
         id: check_artifacts
         run: |
           echo "다운로드된 artifact 목록:"

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -39,7 +39,12 @@ jobs:
 
       - name: extract changed module names
         id: extract
-        run: .github/scripts/extract-changed-modules.sh ${{ github.base_ref }}
+        run: |
+          BASE_REF=${{ github.base_ref }}
+          if [ -z "$BASE_REF" ]; then
+            BASE_REF=${{ github.event.before }}
+          fi
+          .github/scripts/extract-changed-modules.sh $BASE_REF
 
       - name: find targets
         id: target


### PR DESCRIPTION
## 🦡️ 관련 이슈
close #41 

## 📍주요 변경 사항

PR이 merge 될 때 돌아가는 CI를 트리거로 CD가 작동합니다.

여기서 CI 가 PR create 가 아니라 Branch push(=PR merge)에 의해 발생해서 변경점이 잡히지 않았고, 이때문에 CD에서 가져가서 사용할 아티팩트(빌드파일)이 생성되지 않았었습니다.

이제 CI 트리거에 따라 Base branch를 확인하고, branch push 이벤트에 의한 경우엔 이전 커밋과 비교해서 변경점을 찾아냅니다.

## 🎸기타

CI CD 어렵네요,,,
