### PR TITLE
md 파일 변경 감지 및 SHA 기반 저장

### DIFF
--- a/module-batch/src/main/kotlin/almumol/ossori/batch/GithubProjectItemProcessor.kt
+++ b/module-batch/src/main/kotlin/almumol/ossori/batch/GithubProjectItemProcessor.kt
@@ -20,13 +20,14 @@ class GithubProjectItemProcessor(
         val repositorySummary = githubClient.getRepository(previousProject.owner, previousProject.name)
         val readMe = githubClient.getReadMe(previousProject.owner, previousProject.name)
 
-        val contributionGuideKey = githubReadMeSender.saveToBucket(readMe)
+        val contributionGuideKey = githubReadMeSender.saveToBucket(previousProject, readMe)
         val calculatedMetrics = githubMetricsCalculator.calculateMetrics(repositorySummary, commits, pullRequests, contributors)
 
         return previousProject.copy(
             countingStar = repositorySummary.stargazersCount,
             issueCount = repositorySummary.openIssuesCount,
             contributionGuideKey = contributionGuideKey,
+            contributionGuideSha = readMe.sha,
             issueFrequency = calculatedMetrics.issueCreationRate,
             timeToMerge = calculatedMetrics.averageMergeTime,
             pullRequestFrequency = calculatedMetrics.pullRequestCreationRate,

--- a/module-batch/src/main/kotlin/almumol/ossori/batch/GithubReadMeSender.kt
+++ b/module-batch/src/main/kotlin/almumol/ossori/batch/GithubReadMeSender.kt
@@ -1,11 +1,17 @@
 package almumol.ossori.batch
 
 import almumol.ossori.core.client.dto.response.GithubContentResponse
+import almumol.ossori.core.domain.project.domain.Project
 import org.springframework.stereotype.Component
 
 @Component
 class GithubReadMeSender {
-    fun saveToBucket(githubContentResponse: GithubContentResponse): String {
+    fun saveToBucket(project: Project, githubContentResponse: GithubContentResponse): String? {
+        if (project.hasSameContents(githubContentResponse.sha)) {
+            return project.contributionGuideKey;
+        }
+
+        // bucket api 호출
         throw NotImplementedError("This method is not implemented yet.")
     }
 }

--- a/module-core/module-domain/src/main/kotlin/almumol/ossori/core/domain/project/domain/Project.kt
+++ b/module-core/module-domain/src/main/kotlin/almumol/ossori/core/domain/project/domain/Project.kt
@@ -33,6 +33,9 @@ data class Project(
     // CONTRIBUTING.md
     val contributionGuideKey: String? = null,
 
+    // CONTRIBUTING.md SHA
+    val contributionGuideSha: String? = null,
+
     // 이슈 생성 빈도
     @Column(nullable = false)
     val issueFrequency: Double,
@@ -56,4 +59,8 @@ data class Project(
     // PR 최초 응답 시간
     @Column(nullable = false)
     val firstResponseTimeOfPullRequest: Double,
-)
+) {
+    fun hasSameContents(sha: String): Boolean {
+        return this.contributionGuideSha == sha
+    }
+}

--- a/module-core/module-domain/src/test/kotlin/almumol/ossori/core/domain/project/domain/ProjectTest.kt
+++ b/module-core/module-domain/src/test/kotlin/almumol/ossori/core/domain/project/domain/ProjectTest.kt
@@ -1,0 +1,34 @@
+package almumol.ossori.core.domain.project.domain
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class ProjectTest {
+
+    @Test
+    @DisplayName("CONTRIBUTING.md 저장 시 같은 SHA면 동일한 내용으로 간주")
+    fun hasSameContents() {
+        Project(
+            id = 1,
+            owner = "owner",
+            name = "name",
+            description = "description",
+            githubLink = "githubLink",
+            countingStar = 100,
+            issueCount = 10,
+            contributionGuideKey = "key",
+            contributionGuideSha = "sha123",
+            issueFrequency = 1.0,
+            timeToMerge = 2.0,
+            pullRequestFrequency = 3.0,
+            uniqueContributors = 5,
+            starDifference = 20,
+            firstResponseTimeOfPullRequest = 4.0
+        ).let { project ->
+            assertTrue(project.hasSameContents("sha123"))
+            assertFalse(project.hasSameContents("differentSha"))
+        }
+    }
+}


### PR DESCRIPTION
## 🦡️ 관련 이슈
close #42

## 📍주요 변경 사항
translate 들어가기 전 translate 되지 않아야 할 케이스를 고려하여 변경 감지 로직 추가하였습니다~

- md 파일의 SHA 값을 데이터베이스에 저장하도록 엔티티 컬럼 추가
- 기존 저장된 SHA 값과 비교하여 변경된 경우에만 데이터 업데이트
  - GitHub 레포 조회 시 변경되지 않은 README 파일에 대해 불필요한 데이터 업데이트 방지

## 🎸기타
translate pr 은 따로 올리겠스빈다~